### PR TITLE
feat: implement creation form

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,17 +1,20 @@
 <main>
   <h1>Galleria di Arte Generativa</h1>
-  
+
+  <app-creation-form (creationAdded)="onCreationAdded($event)"></app-creation-form>
+
+  <hr />
+
   <section class="gallery">
     @for (creation of creations(); track creation.id) {
-      <article>
-        <h2>{{ creation.name }}</h2>
-        <p>di {{ creation.author }}</p>
-        <pre>{{ creation.params | json }}</pre>
-      </article>
+    <article>
+      <h2>{{ creation.name }}</h2>
+      <p>di {{ creation.author }}</p>
+      <pre>{{ creation.params | json }}</pre>
+    </article>
     } @empty {
-      <p>Caricamento delle creazioni in corso...</p>
+    <p>Caricamento delle creazioni in corso...</p>
     }
   </section>
 </main>
-
 <router-outlet />

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -3,10 +3,11 @@ import { RouterOutlet } from '@angular/router';
 import { ApiService } from './services/api';
 import { Creation } from './models/creation.model';
 import { CommonModule } from '@angular/common';
+import { CreationForm } from './components/creation-form/creation-form';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, CommonModule],
+  imports: [RouterOutlet, CommonModule, CreationForm],
   templateUrl: './app.html',
   styleUrl: './app.scss',
 })
@@ -23,5 +24,9 @@ export class App implements OnInit {
     this.apiService.getCreations().subscribe((creations) => {
       this.creations.set(creations);
     });
+  }
+
+  onCreationAdded(newCreation: Creation): void {
+    this.creations.update((currenteCreation) => [...currenteCreation, newCreation]);
   }
 }

--- a/src/app/components/creation-form/creation-form.html
+++ b/src/app/components/creation-form/creation-form.html
@@ -1,0 +1,16 @@
+<form [formGroup]="creationForm" (ngSubmit)="onSubmit()">
+  <h3>Crea una Nuova Opera</h3>
+  <div>
+    <label for="name">Nome Opera:</label>
+    <input id="name" type="text" formControlName="name" />
+  </div>
+  <div>
+    <label for="author">Autore:</label>
+    <input id="author" type="text" formControlName="author" />
+  </div>
+  <div>
+    <label for="params">Parametri (JSON):</label>
+    <textarea id="params" formControlName="params" rows="3"></textarea>
+  </div>
+  <button type="submit" [disabled]="creationForm.invalid">Crea</button>
+</form>

--- a/src/app/components/creation-form/creation-form.spec.ts
+++ b/src/app/components/creation-form/creation-form.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CreationForm } from './creation-form';
+
+describe('CreationForm', () => {
+  let component: CreationForm;
+  let fixture: ComponentFixture<CreationForm>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CreationForm]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CreationForm);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/creation-form/creation-form.ts
+++ b/src/app/components/creation-form/creation-form.ts
@@ -1,0 +1,41 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, inject, Output } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ApiService } from '../../services/api';
+import { Creation } from '../../models/creation.model';
+
+@Component({
+  selector: 'app-creation-form',
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './creation-form.html',
+  styleUrl: './creation-form.scss',
+})
+export class CreationForm {
+  private formBuilder = inject(FormBuilder);
+  private apiService = inject(ApiService);
+
+  @Output() creationAdded = new EventEmitter<Creation>();
+
+  creationForm: FormGroup = this.formBuilder.group({
+    name: ['', Validators.required],
+    author: ['', Validators.required],
+    params: ['{"color": "#FF0000"}', Validators.required],
+  });
+
+  onSubmit(): void {
+    if (this.creationForm.invalid) return;
+
+    const formValue = this.creationForm.value;
+    const creationData = {
+      ...formValue,
+      params: JSON.parse(formValue.params),
+    };
+
+    this.apiService.createCreation(creationData).subscribe((newCreation) => {
+      console.log(`🤙 ~ CreationForm ~ onSubmit ~ newCreation:`, newCreation);
+
+      this.creationAdded.emit(newCreation);
+      this.creationForm.reset();
+    });
+  }
+}

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -16,4 +16,8 @@ export class ApiService {
   getCreations(): Observable<Creation[]> {
     return this.http.get<Creation[]>(`${this.apiUrl}/creations`);
   }
+
+  createCreation(creationData: { name: string, author: string, params: any }): Observable<Creation> {
+    return this.http.post<Creation>(`${this.apiUrl}/creations`, creationData);
+  }
 }


### PR DESCRIPTION
Questa PR introduce la funzionalità per creare nuove opere d'arte.

**Cambiamenti implementati:**

- Creato il `CreationFormComponent` con Reactive Forms per gestire l'input dell'utente.
- Aggiunto il metodo `createCreation` all'ApiService per inviare i dati al backend.
- Il `AppComponent` ora mostra il form e aggiorna la lista dinamicamente quando un nuovo elemento viene aggiunto, senza ricaricare la pagina.