### PR TITLE
feat: implement delete creation functionality

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -11,6 +11,8 @@
       <h2>{{ creation.name }}</h2>
       <p>di {{ creation.author }}</p>
       <pre>{{ creation.params | json }}</pre>
+
+      <button (click)="onDeleteCreation(creation.id)" class="delete-btn">Elimina</button>
     </article>
     } @empty {
     <p>Caricamento delle creazioni in corso...</p>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -29,4 +29,14 @@ export class App implements OnInit {
   onCreationAdded(newCreation: Creation): void {
     this.creations.update((currenteCreation) => [...currenteCreation, newCreation]);
   }
+
+  onDeleteCreation(id: number): void {
+    this.apiService.deleteCreation(id).subscribe(() => {
+      // Quando la chiamata API ha successo, aggiorniamo il nostro signal
+      // filtrando l'array per rimuovere l'elemento con l'ID eliminato.
+      this.creations.update(currentCreations =>
+        currentCreations.filter(creation => creation.id !== id)
+      );
+    });
+  }
 }

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -20,4 +20,8 @@ export class ApiService {
   createCreation(creationData: { name: string, author: string, params: any }): Observable<Creation> {
     return this.http.post<Creation>(`${this.apiUrl}/creations`, creationData);
   }
+
+  deleteCreation(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/creations/${id}`);
+  }
 }


### PR DESCRIPTION
Questa PR introduce la funzionalità completa per la cancellazione di una "Creation", implementando i controlli necessari sul frontend.

### Logica di Riferimento
Come parte delle operazioni CRUD standard (Create, Read, Update, Delete), questa modifica implementa la "D" (Delete). L'utente può ora rimuovere una risorsa precedentemente creata.

### Modifiche al Frontend (UI)
- **Aggiunta Pulsante "Elimina":** Ogni elemento nella galleria ora presenta un pulsante per la cancellazione.
- **Aggiornamento `ApiService`:** Il servizio è stato esteso con un metodo `deleteCreation(id)` che esegue una richiesta `HTTP DELETE`. L'Observable restituito è di tipo `void` per gestire correttamente la risposta `204`.
- **Aggiornamento `AppComponent`:** È stato aggiunto il metodo `onDeleteCreation(id)` che invoca il servizio. In caso di successo, aggiorna lo `signal` delle `creations` filtrando l'elemento rimosso. Questo garantisce un **aggiornamento reattivo della UI** senza necessità di ricaricare la pagina.